### PR TITLE
Allow configuration for known sections

### DIFF
--- a/pylsp_isort/plugin.py
+++ b/pylsp_isort/plugin.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Optional, TypedDict, Union
 
 import isort
+from isort.settings import KNOWN_PREFIX
 from pylsp import hookimpl
 from pylsp.config.config import Config
 from pylsp.workspace import Document
@@ -89,7 +90,7 @@ def isort_config(
 
     defined_args = set(getattr(isort.Config, "__dataclass_fields__", {}).keys())
     for key, value in settings.items():
-        if key in defined_args:
+        if key in defined_args or key.startswith(KNOWN_PREFIX):
             config_kwargs[key] = value
         else:
             unsupported_kwargs[key] = value

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -72,6 +72,20 @@ def test_run_isort(text, settings, expected):
             isort.Config(profile="black"),
             False,
         ),
+        (
+            {
+                "sections": ["FUTURE", "SECTION_A", "SECTION_B"],
+                "known_section_a": ["module_a"],
+                "known_section_b": ["module_b"],
+             },
+            None,
+            isort.Config(
+                sections=["FUTURE", "SECTION_A", "SECTION_B"],
+                known_section_a=["module_a"],
+                known_section_b=["module_b"],
+            ),
+            True,
+        ),
     ],
 )
 def test_isort_config(settings, target_path, expected, check_sources):


### PR DESCRIPTION
First of all thanks for the plugin, it works very well.

At work we have to import a module at the beggining of the file because we rely on some side effects from the import.
I wanted to force the import to move to the top and it seems the recommended way is to define custom sections together with https://pycqa.github.io/isort/docs/configuration/options.html#known-other.

So my config would look like:
```json
{"sections": ["FUTURE", "THE_SECTION", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"], "known_the_section": ["the_module"]}
```

Since these `known_{section}` keys are dynamic, they are not present in the dataclass definition for `_Config`, and are filtered before the `isort.Config` is created in the plugin.

The proposed change allows any config key that starts with the `known_` prefix. I considered generating the list of valid `known_` keys from the user-defined sections, but isort already validates that and didn't see the need for duplicating the logic.

An alternative approach would be to add the module to the `FUTURE` section but that is discouraged: https://pycqa.github.io/isort/docs/configuration/options.html#known-future-library 